### PR TITLE
fix for correctly archiving WebArchive subresources

### DIFF
--- a/Sources/WebArchiver/WebArchive.swift
+++ b/Sources/WebArchiver/WebArchive.swift
@@ -38,6 +38,13 @@ struct WebArchiveResource: Encodable {
     let url: URL
     let data: Data
     let mimeType: String
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(url.absoluteString, forKey: .url)
+        try container.encode(data, forKey: .data)
+        try container.encode(mimeType, forKey: .mimeType)
+    }
 }
 struct WebArchiveMainResource: Encodable {
     


### PR DESCRIPTION
just needed this change to be able to load subresources like images when viewing the unarchived content while being offline. 